### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -94,5 +94,12 @@ echo -e "export PATH=\"$PATH:/snap/bin\"" >> ~/.profile
 source ~/.profile
 
 ## END
-cd ~
-rm install.sh
+SCRIPT_PATH="`dirname \"$0\"`"              # relative
+SCRIPT_PATH="`( cd \"$SCRIPT_PATH\" && pwd )`"  # absolutized and normalized
+if [ -z "$SCRIPT_PATH" ] ; then
+  # error; for some reason, the path is not accessible
+  # to the script (e.g. permissions re-evaled after suid)
+  exit 1  # fail
+fi
+
+rm $SCRIPT_PATH/install.sh


### PR DESCRIPTION
The removal of the installation script (install.sh) didn't work correctly because it depended on a relative path and not an absolute one. This added code will make it work wherever the install.sh is running from.